### PR TITLE
Replace REST cache with Azure Cache2

### DIFF
--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -12,6 +12,31 @@ jobs:
       ESY__CACHE_INSTALL_PATH: ${{ parameters.ESY__CACHE_INSTALL_PATH }}
       CACHE_FOLDER: $(Pipeline.Workspace)/cache
     steps: 
+      - powershell: $Env:Path
+        continueOnError: true
+        condition: eq(variables['AGENT.OS'], 'Windows_NT')
+        displayName: "Print env in powershell"
+      # Needed so that the mingw tar doesn't shadow the system tar. See
+      # pipelines.yaml. We need windows bsdtar from system32, not the mingw
+      # one. Note powershell doesn't need escaping of backslashes.
+      - powershell: Write-Host "##vso[task.setvariable variable=PATH;]C:\Windows\system32;${env:PATH}"
+        continueOnError: true
+        condition: eq(variables['AGENT.OS'], 'Windows_NT')
+        displayName: "Make sure windows/system32 is at front of path if windows"
+      - powershell: $Env:Path
+        continueOnError: true
+        condition: eq(variables['AGENT.OS'], 'Windows_NT')
+        displayName: "Print env in powershell"
+      - powershell: get-command tar
+        continueOnError: true
+        condition: eq(variables['AGENT.OS'], 'Windows_NT')
+        displayName: "Print where tar is located"
+      - powershell: tar --help
+        continueOnError: true
+        condition: eq(variables['AGENT.OS'], 'Windows_NT')
+        displayName: "Print tar help"
+      - bash: env
+        displayName: "Print environment"
       - template: utils/use-node.yml
       - template: utils/use-esy.yml
       - template: utils/restore-build-cache.yml

--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -8,60 +8,10 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
       demands: node.js
     timeoutInMinutes: 120 # This is mostly for Windows
+    variables:
+      ESY__CACHE_INSTALL_PATH: ${{ parameters.ESY__CACHE_INSTALL_PATH }}
+      CACHE_FOLDER: $(Pipeline.Workspace)/cache
     steps: 
-      - powershell: $Env:Path
-        continueOnError: true
-        condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))))
-        displayName: "Print env in powershell"
-      # Needed so that the mingw tar doesn't shadow the system tar. See
-      # pipelines.yaml. We need windows bsdtar from system32, not the mingw
-      # one. Note powershell doesn't need escaping of backslashes.
-      - powershell: Write-Host "##vso[task.setvariable variable=PATH;]C:\Windows\system32;${env:PATH}"
-        continueOnError: true
-        condition: eq(variables['AGENT.OS'], 'Windows_NT')
-        displayName: "Make sure windows/system32 is at front of path if windows"
-      - powershell: $Env:Path
-        continueOnError: true
-        condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))))
-        displayName: "Print env in powershell"
-      - powershell: get-command tar
-        continueOnError: true
-        condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))))
-        displayName: "Print where tar is located"
-      - powershell: tar --help
-        continueOnError: true
-        condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))))
-        displayName: "Print tar help"
-      - bash: |
-          # COMPUTE THE ESY INSTALL CACHE LOCATION AHEAD OF TIME
-          DESIRED_LEN="86"
-          # Note: This will need to change when upgrading esy version
-          # that reenables long paths on windows.
-          if [ "$AGENT_OS" == "Windows_NT" ]; then
-            DESIRED_LEN="33"
-          fi
-          HOME_ESY3="$HOME/.esy/3"
-          HOME_ESY3_LEN=${#HOME_ESY3}
-          NUM_UNDERS=$(echo "$(($DESIRED_LEN-$HOME_ESY3_LEN))")
-          UNDERS=$(printf "%-${NUM_UNDERS}s" "_")
-          UNDERS="${UNDERS// /_}"
-          THE_ESY__CACHE_INSTALL_PATH=${HOME_ESY3}${UNDERS}/i
-          if [ "$AGENT_OS" == "Windows_NT" ]; then
-            THE_ESY__CACHE_INSTALL_PATH=$( cygpath --mixed --absolute "$THE_ESY__CACHE_INSTALL_PATH")
-          fi
-          echo "THE_ESY__CACHE_INSTALL_PATH: $THE_ESY__CACHE_INSTALL_PATH"
-          # This will be exposed as an env var ESY__CACHE_INSTALL_PATH, or an
-          # Azure var esy__cache_install_path
-          echo "##vso[task.setvariable variable=esy__cache_install_path]$THE_ESY__CACHE_INSTALL_PATH"
-      # - bash: |
-      #     which esy
-      #     echo "$( which esy )"
-      #     echo "##vso[task.setvariable variable=esy_bin_location]$(which esy)"
-      #   displayName: "Find esy binary"
-      # - bash: echo ${ESY_BIN_LOCATION}
-      # displayName: "Print esy bin location"
-      - bash: env
-        displayName: "Print environment"
       - template: utils/use-node.yml
       - template: utils/use-esy.yml
       - script: "esy install"

--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -14,9 +14,9 @@ jobs:
     steps: 
       - template: utils/use-node.yml
       - template: utils/use-esy.yml
+      - template: utils/restore-build-cache.yml
       - script: "esy install"
         displayName: "esy install"
-      - template: utils/restore-build-cache.yml
       - script: "esy build"
         displayName: "esy build"
       - template: utils/create-docs.yml

--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -8,9 +8,6 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
       demands: node.js
     timeoutInMinutes: 120 # This is mostly for Windows
-    variables:
-      ESY__CACHE_INSTALL_PATH: ${{ parameters.ESY__CACHE_INSTALL_PATH }}
-      CACHE_FOLDER: $(Pipeline.Workspace)/cache
     steps: 
       - powershell: $Env:Path
         continueOnError: true

--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -36,9 +36,9 @@ jobs:
         displayName: "Print environment"
       - template: utils/use-node.yml
       - template: utils/use-esy.yml
-      - template: utils/restore-build-cache.yml
       - script: "esy install"
         displayName: "esy install"
+      - template: utils/restore-build-cache.yml
       - script: "esy build"
         displayName: "esy build"
       - template: utils/create-docs.yml

--- a/.ci/utils/publish-build-cache.yml
+++ b/.ci/utils/publish-build-cache.yml
@@ -4,6 +4,6 @@ steps:
   - script: "esy export-dependencies"
     continueOnError: true
     displayName: "esy export-dependencies"
-
-  - bash: pwd && ls _export/* && mv _export '$(CACHE_FOLDER)' && ls '$(CACHE_FOLDER)/_export/'
-    displayName: '[Cache][Publish] move export to cache dir'
+    
+  - pwsh: Copy-Item -Path _export -Destination $(CACHE_FOLDER) -Recurse
+    displayName: '[Cache][Publish] Copy builds to be cached'

--- a/.ci/utils/publish-build-cache.yml
+++ b/.ci/utils/publish-build-cache.yml
@@ -1,3 +1,9 @@
 steps:
-  - pwsh: Copy-Item -Path $(ESY__CACHE_INSTALL_PATH) -Destination $(CACHE_FOLDER) -Recurse
-    displayName: '[Cache][Publish] Copy builds to be cached'
+  # continueOnError because on windows it has a permission denied error but the
+  # export succeeds.
+  - script: "esy export-dependencies"
+    continueOnError: true
+    displayName: "esy export-dependencies"
+
+  - bash: pwd && ls _export/* && mv _export '$(CACHE_FOLDER)' && ls '$(CACHE_FOLDER)/_export/'
+    displayName: '[Cache][Publish] move export to cache dir'

--- a/.ci/utils/publish-build-cache.yml
+++ b/.ci/utils/publish-build-cache.yml
@@ -3,4 +3,5 @@ steps:
   # export succeeds.
   - script: "esy export-dependencies"
     continueOnError: true
+    condition: eq(variables.CACHE_RESTORED, 'false')
     displayName: "esy export-dependencies"

--- a/.ci/utils/publish-build-cache.yml
+++ b/.ci/utils/publish-build-cache.yml
@@ -4,6 +4,3 @@ steps:
   - script: "esy export-dependencies"
     continueOnError: true
     displayName: "esy export-dependencies"
-    
-  - pwsh: Copy-Item -Path _export -Destination $(CACHE_FOLDER) -Recurse
-    displayName: '[Cache][Publish] Copy builds to be cached'

--- a/.ci/utils/publish-build-cache.yml
+++ b/.ci/utils/publish-build-cache.yml
@@ -1,37 +1,3 @@
-# Steps for publishing project cache
-
 steps:
-  - bash: 'mkdir -p $(Build.StagingDirectory)'
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'))
-    displayName: '[Cache][Publish] Create cache directory'
-
-  # continueOnError because on windows it has a permission denied error but the
-  # export succeeds.
-  - script: "esy export-dependencies"
-    continueOnError: true
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'))
-    displayName: "esy export-dependencies"
-
-  - bash: pwd && ls _export/* && mv _export '$(Build.StagingDirectory)' && ls '$(Build.StagingDirectory)/_export/'
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'))
-    displayName: '[Cache][Publish] move export to staging dir'
-
-  # - bash: cd $ESY__CACHE_INSTALL_PATH && tar -czf $(Build.StagingDirectory)/esy-cache.tar .
-  #   workingDirectory: ''
-  #   condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'))
-  #   displayName: '[Cache][Publish] Tar esy cache directory'
-
-  # - bash: 'cd $(ESY__NPM_ROOT) && tar -czf $(Build.StagingDirectory)/npm-cache.tar .'
-  #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
-  #   displayName: '[Cache][Publish] Tar npm cache directory'
-
-  - task: PublishBuildArtifacts@1
-    displayName: '[Cache][Publish] Upload tarball'
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'))
-    # TODO: The CI Build caches are pulled down by the last successful buildID
-    # for the target branch.
-    inputs:
-        pathToPublish: '$(Build.StagingDirectory)'
-        artifactName: 'cache-$(Agent.OS)-install'
-        parallel: true
-        parallelCount: 8
+  - pwsh: Copy-Item -Path $(ESY__CACHE_INSTALL_PATH) -Destination $(CACHE_FOLDER) -Recurse
+    displayName: '[Cache][Publish] Copy builds to be cached'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -29,9 +29,10 @@ steps:
       
   - task: Cache@2
     inputs:
-      key: esy | $(Agent.OS) | esy.lock/index.json
+      # "v1" prefix added just to keep the ability to clear a cache without having to wait 7 days
+      key: v1 | esy | $(Agent.OS) | esy.lock/index.json
+      restoreKeys: v1 | esy | $(Agent.OS)
       path: $(CACHE_FOLDER)
-      restoreKeys: esy | $(Agent.OS)
       cacheHitVar: CACHE_RESTORED
     displayName: '[Cache] esy packages'
 

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -31,6 +31,7 @@ steps:
     inputs:
       key: cache_key_2 | esy | $(Agent.OS) | esy.lock/index.json
       path: $(CACHE_FOLDER)
+      restoreKeys: esy | $(Agent.OS)
       cacheHitVar: CACHE_RESTORED
     displayName: '[Cache] esy packages'
 

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -34,12 +34,9 @@ steps:
       # "v1" prefix added just to keep the ability to clear a cache without having to wait 7 days
       key: v1b | esy | $(Agent.OS) | esy.lock/index.json
       restoreKeys: v1b | esy | $(Agent.OS)
-      path: $(CACHE_FOLDER)
+      path: _export
       cacheHitVar: CACHE_RESTORED
     displayName: '[Cache] esy packages'
-
-  - bash: mv '${CACHE_FOLDER}/_export' '${PROJECT_DIR}/_export'
-    condition: eq(variables.CACHE_RESTORED, 'true')
 
   - powershell: esy.cmd import-dependencies
     continueOnError: true

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -1,101 +1,43 @@
-# Steps for restoring project cache
-
+# The cache key is built up of the following:
+# We use a string that we can change to bust the cache
+# The string "esy"
+# The string for the OS
+# The hash of the lock file
 steps:
-  - bash: 'mkdir -p $(Build.StagingDirectory)'
-    condition: and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch'])))
-    displayName: '[Cache][Publish] Create cache directory'
-
-  # TODO: This can be done in parallel with installing node, and esy
-  # (which would save a bunch of time on windows)
-  - task: Bash@3
-    condition: and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch'])))
-    displayName: '[Cache][Restore] Restoring build cache using REST API'
-    continueOnError: true
-    inputs:
-      targetType: 'inline' # Optional. Options: filePath, inline
-      script: |
-        # If org name is reasonml then REST_BASE will be: https://dev.azure.com/reasonml/
-        REST_BASE="${SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}"
-        PROJ="$SYSTEM_TEAMPROJECT"
-        ART_NAME="cache-${AGENT_OS}-install"
-        fetchLatestBuild() {
-          PREFIX="branchName=refs%2Fheads%2F"
-          BRANCH=${PREFIX}${SYSTEM_PULLREQUEST_TARGETBRANCH}
-          FILTER='deletedFilter=excludeDeleted&statusFilter=completed&resultFilter=succeeded'
-          LATEST='queryOrder=finishTimeDescending&$top=1'
-          REST_BUILDS="$REST_BASE/$PROJ/_apis/build/builds?${FILTER}&${BRANCH}&${LATEST}&api-version=4.1"
-          echo "Rest call for builds: $REST_BUILDS"
-          REST_BUILDS_RESP=$(curl "$REST_BUILDS")
-          if [[ $REST_BUILDS_RESP =~ (\"web\":\{\"href\":\")([^\"]*) ]]; then LATEST_BUILD_PAGE="${BASH_REMATCH[2]}"; else LATEST_BUILD_PAGE=""; fi
-          if [[ $REST_BUILDS_RESP =~ (\"badge\":\{\"href\":\")([^\"]*) ]]; then LATEST_BUILD_BADGE="${BASH_REMATCH[2]}"; else LATEST_BUILD_BADGE=""; fi
-          if [[ $REST_BUILDS_RESP =~ (\"id\":)([^,]*) ]]; then LATEST_BUILD_ID="${BASH_REMATCH[2]}"; else LATEST_BUILD_ID=""; fi
-        }
-        fetchLatestBuild
-        fetchArtifactURL() {
-          REST_ART="$REST_BASE/$PROJ/_apis/build/builds/$LATEST_BUILD_ID/artifacts?artifactName=$ART_NAME&api-version=4.1"
-          echo "Rest call for artifacts: $REST_ART"
-          if [[ $(curl $REST_ART) =~ (downloadUrl\":\")([^\"]*) ]]; then LATEST_ART_URL="${BASH_REMATCH[2]}"; else LATEST_ART_URL=""; fi
-        }
-        downloadArtifactAndContinue() {
-          if [ -z "$LATEST_ART_URL" ]
-          then
-            echo "No latest artifact for merge-target branch found at URL $REST_ART"
-          else
-            curl "$LATEST_ART_URL" > "${BUILD_STAGINGDIRECTORY}/$ART_NAME.zip"
-            PROJECT_DIR=$PWD
-            cd $BUILD_STAGINGDIRECTORY
-            unzip "$ART_NAME.zip"
-            echo "Using Dependency cache for buildID: $LATEST_BUILD_ID"
-            echo "Build log for build that produced the cache: $LATEST_BUILD_PAGE"
-            echo "Build badge for build that produced the cache: $LATEST_BUILD_BADGE"
-            echo "Build artifact from build that produced the cache: $LATEST_ART_URL"
-            echo "Restoring build cache into:"
-            mkdir -p $ESY__CACHE_INSTALL_PATH
-            echo $ESY__CACHE_INSTALL_PATH
-            echo "##vso[task.setvariable variable=esy_export_dir_to_import]${BUILD_STAGINGDIRECTORY}/${ART_NAME}/_export"
-            if [[ -d ${ART_NAME}/_export ]]; then
-              echo "Cached builds to import from ${ART_NAME}/_export in next CI step"
-              ls ${ART_NAME}/_export
-              mv ${ART_NAME}/_export ${PROJECT_DIR}/_export
-            else
-              echo "No _export directory to import from build cache"
-              echo "Here's the contents of build cache:"
-              find ${BUILD_STAGINGDIRECTORY}
-            fi
-          fi
-        }
-        fetchArtifactURL
-        downloadArtifactAndContinue
+  - bash: |
+      # COMPUTE THE ESY INSTALL CACHE LOCATION AHEAD OF TIME
+      DESIRED_LEN="86"
+      # Note: This will need to change when upgrading esy version
+      # that reenables long paths on windows.
+      if [ "$AGENT_OS" == "Windows_NT" ]; then
+        DESIRED_LEN="33"
+      fi
+      HOME_ESY3="$HOME/.esy/3"
+      HOME_ESY3_LEN=${#HOME_ESY3}
+      NUM_UNDERS=$(echo "$(($DESIRED_LEN-$HOME_ESY3_LEN))")
+      UNDERS=$(printf "%-${NUM_UNDERS}s" "_")
+      UNDERS="${UNDERS// /_}"
+      THE_ESY__CACHE_INSTALL_PATH=${HOME_ESY3}${UNDERS}/i
+      if [ "$AGENT_OS" == "Windows_NT" ]; then
+        THE_ESY__CACHE_INSTALL_PATH=$( cygpath --mixed --absolute "$THE_ESY__CACHE_INSTALL_PATH")
+      fi
+      echo "THE_ESY__CACHE_INSTALL_PATH: $THE_ESY__CACHE_INSTALL_PATH"
+      # This will be exposed as an env var ESY__CACHE_INSTALL_PATH, or an
+      # Azure var esy__cache_install_path
+      echo "##vso[task.setvariable variable=esy__cache_install_path]$THE_ESY__CACHE_INSTALL_PATH"
+    displayName: '[Cache] calculate esy store path'
       
-  - powershell: esy.cmd import-dependencies
-    continueOnError: true
-    condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))))
-    displayName: "esy import-dependencies if windows (build cache from CI cache)"
-
-  - bash: esy import-dependencies
-    continueOnError: true
-    condition: and(ne(variables['AGENT.OS'], 'Windows_NT'), and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))))
-    displayName: "esy import-dependencies if not windows (build cache from CI cache)"
-    
-  # Remove as soon as https://github.com/esy/esy/pull/969 is resolved.
-  # For now, windows won't use build cache for problematic package.
-  - task: Bash@3
-    continueOnError: true
-    condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))))
-    displayName: 'Remove ocamlfind prebuilts if on Windows'
+  - task: Cache@2
     inputs:
-      targetType: 'inline' # Optional. Options: filePath, inline
-      script: |
-        ls ${ESY__CACHE_INSTALL_PATH}
-        rm -r ${ESY__CACHE_INSTALL_PATH}/opam__s__ocamlfind*
+      key: cache_key_2 | esy | $(Agent.OS) | esy.lock/index.json
+      path: $(CACHE_FOLDER)
+      cacheHitVar: CACHE_RESTORED
+    displayName: '[Cache] esy packages'
 
-  - bash: 'rm -rf _import'
-    continueOnError: true
-    condition: and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch'])))
-    displayName: 'Remove import directory'
+  - pwsh: 'New-Item $(ESY__CACHE_INSTALL_PATH) -ItemType Directory'
+    condition: eq(variables.CACHE_RESTORED, 'true')
+    displayName: '[Cache][Restore] Create esy cache directory'
 
-  - bash: 'rm -rf *'
-    continueOnError: true
-    workingDirectory: '$(Build.StagingDirectory)'
-    condition: and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch'])))
-    displayName: '[Cache][Restore] Clean up staging dir'
+  - pwsh: Move-Item -Path $(CACHE_FOLDER)/* -Destination $(ESY__CACHE_INSTALL_PATH)
+    displayName: '[Cache][Restore] Move downloaded cache in place'
+    condition: eq(variables.CACHE_RESTORED, 'true')

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -49,7 +49,7 @@ steps:
       script: |
         ls _export
         ls ${ESY__CACHE_INSTALL_PATH}
-        # rm -r _export/opam__s__ocamlfind*
+        rm -r _export/opam__s__ocamlfind*
         rm -r _export/reason_native__s__rely*
 
   - powershell: esy.cmd import-dependencies

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -38,16 +38,6 @@ steps:
       cacheHitVar: CACHE_RESTORED
     displayName: '[Cache] esy packages'
 
-  - powershell: esy.cmd import-dependencies
-    continueOnError: true
-    condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
-    displayName: "esy import-dependencies if windows (build cache from CI cache)"
-
-  - bash: esy import-dependencies
-    continueOnError: true
-    condition: and(ne(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
-    displayName: "esy import-dependencies if not windows (build cache from CI cache)"    
-
   # Remove as soon as https://github.com/esy/esy/pull/969 is resolved.
   # For now, windows won't use build cache for problematic package.
   - task: Bash@3
@@ -59,7 +49,18 @@ steps:
       script: |
         ls _export
         ls ${ESY__CACHE_INSTALL_PATH}
-        rm -r ${ESY__CACHE_INSTALL_PATH}/opam__s__ocamlfind*
+        # rm -r _export/opam__s__ocamlfind*
+        rm -r _export/reason_native__s__rely*
+
+  - powershell: esy.cmd import-dependencies
+    continueOnError: true
+    condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
+    displayName: "esy import-dependencies if windows (build cache from CI cache)"
+
+  - bash: esy import-dependencies
+    continueOnError: true
+    condition: and(ne(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
+    displayName: "esy import-dependencies if not windows (build cache from CI cache)"    
 
   - bash: 'rm -rf _import'
     continueOnError: true

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -32,21 +32,11 @@ steps:
   - task: Cache@2
     inputs:
       # "v1" prefix added just to keep the ability to clear a cache without having to wait 7 days
-      key: v1b | esy | $(Agent.OS) | esy.lock/index.json
-      restoreKeys: v1b | esy | $(Agent.OS)
+      key: v1c | esy | $(Agent.OS) | esy.lock/index.json
+      restoreKeys: v1c | esy | $(Agent.OS)
       path: _export
       cacheHitVar: CACHE_RESTORED
     displayName: '[Cache] esy packages'
-
-  - task: Bash@3
-    continueOnError: true
-    condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
-    displayName: 'Remove rely prebuilts if on Windows'
-    inputs:
-      targetType: 'inline' # Optional. Options: filePath, inline
-      script: |
-        ls -la _export
-        rm -r _export/reason_native__s__rely*
 
   - powershell: esy.cmd import-dependencies
     continueOnError: true
@@ -69,7 +59,6 @@ steps:
       script: |
         ls ${ESY__CACHE_INSTALL_PATH}
         rm -r ${ESY__CACHE_INSTALL_PATH}/opam__s__ocamlfind*
-        rm -r ${ESY__CACHE_INSTALL_PATH}/reason_native__s__rely*
 
   - bash: 'rm -rf _import'
     continueOnError: true

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -1,8 +1,8 @@
 # The cache key is built up of the following:
-# We use a string that we can change to bust the cache
-# The string "esy"
-# The string for the OS
-# The hash of the lock file
+# - We use a string that we can change to bust the cache
+# - The string "esy"
+# - The string for the OS
+# - The hash of the lock file
 steps:
   - bash: |
       # COMPUTE THE ESY INSTALL CACHE LOCATION AHEAD OF TIME

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -35,6 +35,10 @@ steps:
       cacheHitVar: CACHE_RESTORED
     displayName: '[Cache] esy packages'
 
+  - pwsh: 'New-Item $(ESY__CACHE_INSTALL_PATH) -ItemType Directory'
+    condition: eq(variables.CACHE_RESTORED, 'true')
+    displayName: '[Cache][Restore] Create esy cache directory'
+
   - pwsh: Move-Item -Path $(CACHE_FOLDER)/* -Destination $(ESY__CACHE_INSTALL_PATH)
     displayName: '[Cache][Restore] Move downloaded cache in place'
     condition: eq(variables.CACHE_RESTORED, 'true')

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -43,14 +43,14 @@ steps:
   - task: Bash@3
     continueOnError: true
     condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
-    displayName: 'Remove ocamlfind prebuilts if on Windows'
+    displayName: 'Remove ocamlfind, rely and console prebuilts if on Windows'
     inputs:
       targetType: 'inline' # Optional. Options: filePath, inline
       script: |
         ls _export
-        ls ${ESY__CACHE_INSTALL_PATH}
         rm -r _export/opam__s__ocamlfind*
         rm -r _export/reason_native__s__rely*
+        rm -r _export/reason_native__s__console*
 
   - powershell: esy.cmd import-dependencies
     continueOnError: true

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -6,6 +6,8 @@
 steps:
   - bash: |
       # COMPUTE THE ESY INSTALL CACHE LOCATION AHEAD OF TIME
+      # The cache location is only needed for some issues that require to remove
+      # individual packages from cache (see ocamlfind below)
       DESIRED_LEN="86"
       # Note: This will need to change when upgrading esy version
       # that reenables long paths on windows.
@@ -26,20 +28,42 @@ steps:
       # Azure var esy__cache_install_path
       echo "##vso[task.setvariable variable=esy__cache_install_path]$THE_ESY__CACHE_INSTALL_PATH"
     displayName: '[Cache] calculate esy store path'
-      
+    
   - task: Cache@2
     inputs:
       # "v1" prefix added just to keep the ability to clear a cache without having to wait 7 days
-      key: v1 | esy | $(Agent.OS) | esy.lock/index.json
-      restoreKeys: v1 | esy | $(Agent.OS)
+      key: v1b | esy | $(Agent.OS) | esy.lock/index.json
+      restoreKeys: v1b | esy | $(Agent.OS)
       path: $(CACHE_FOLDER)
       cacheHitVar: CACHE_RESTORED
     displayName: '[Cache] esy packages'
 
-  - pwsh: 'New-Item $(ESY__CACHE_INSTALL_PATH) -ItemType Directory'
+  - bash: mv '${CACHE_FOLDER}/_export' '${PROJECT_DIR}/_export'
     condition: eq(variables.CACHE_RESTORED, 'true')
-    displayName: '[Cache][Restore] Create esy cache directory'
 
-  - pwsh: Move-Item -Path $(CACHE_FOLDER)/* -Destination $(ESY__CACHE_INSTALL_PATH)
-    displayName: '[Cache][Restore] Move downloaded cache in place'
+  - powershell: esy.cmd import-dependencies
+    continueOnError: true
+    condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
+    displayName: "esy import-dependencies if windows (build cache from CI cache)"
+
+  - bash: esy import-dependencies
+    continueOnError: true
+    condition: and(ne(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
+    displayName: "esy import-dependencies if not windows (build cache from CI cache)"    
+
+  # Remove as soon as https://github.com/esy/esy/pull/969 is resolved.
+  # For now, windows won't use build cache for problematic package.
+  - task: Bash@3
+    continueOnError: true
+    condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
+    displayName: 'Remove ocamlfind prebuilts if on Windows'
+    inputs:
+      targetType: 'inline' # Optional. Options: filePath, inline
+      script: |
+        ls ${ESY__CACHE_INSTALL_PATH}
+        rm -r ${ESY__CACHE_INSTALL_PATH}/opam__s__ocamlfind*
+
+  - bash: 'rm -rf _import'
+    continueOnError: true
     condition: eq(variables.CACHE_RESTORED, 'true')
+    displayName: 'Remove import directory'

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -35,10 +35,6 @@ steps:
       cacheHitVar: CACHE_RESTORED
     displayName: '[Cache] esy packages'
 
-  - pwsh: 'New-Item $(ESY__CACHE_INSTALL_PATH) -ItemType Directory'
-    condition: eq(variables.CACHE_RESTORED, 'true')
-    displayName: '[Cache][Restore] Create esy cache directory'
-
   - pwsh: Move-Item -Path $(CACHE_FOLDER)/* -Destination $(ESY__CACHE_INSTALL_PATH)
     displayName: '[Cache][Restore] Move downloaded cache in place'
     condition: eq(variables.CACHE_RESTORED, 'true')

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -38,6 +38,16 @@ steps:
       cacheHitVar: CACHE_RESTORED
     displayName: '[Cache] esy packages'
 
+  - task: Bash@3
+    continueOnError: true
+    condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))
+    displayName: 'Remove rely prebuilts if on Windows'
+    inputs:
+      targetType: 'inline' # Optional. Options: filePath, inline
+      script: |
+        ls -la _export
+        rm -r _export/reason_native__s__rely*
+
   - powershell: esy.cmd import-dependencies
     continueOnError: true
     condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), eq(variables.CACHE_RESTORED, 'true'))

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -59,6 +59,7 @@ steps:
       script: |
         ls ${ESY__CACHE_INSTALL_PATH}
         rm -r ${ESY__CACHE_INSTALL_PATH}/opam__s__ocamlfind*
+        rm -r ${ESY__CACHE_INSTALL_PATH}/reason_native__s__rely*
 
   - bash: 'rm -rf _import'
     continueOnError: true

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -7,7 +7,7 @@ steps:
   - bash: |
       # COMPUTE THE ESY INSTALL CACHE LOCATION AHEAD OF TIME
       # The cache location is only needed for some issues that require to remove
-      # individual packages from cache (see ocamlfind below)
+      # individual packages from cache (e.g. ocamlfind below)
       DESIRED_LEN="86"
       # Note: This will need to change when upgrading esy version
       # that reenables long paths on windows.

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -29,7 +29,7 @@ steps:
       
   - task: Cache@2
     inputs:
-      key: cache_key_2 | esy | $(Agent.OS) | esy.lock/index.json
+      key: esy | $(Agent.OS) | esy.lock/index.json
       path: $(CACHE_FOLDER)
       restoreKeys: esy | $(Agent.OS)
       cacheHitVar: CACHE_RESTORED

--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -57,6 +57,7 @@ steps:
     inputs:
       targetType: 'inline' # Optional. Options: filePath, inline
       script: |
+        ls _export
         ls ${ESY__CACHE_INSTALL_PATH}
         rm -r ${ESY__CACHE_INSTALL_PATH}/opam__s__ocamlfind*
 

--- a/.ci/utils/use-esy.yml
+++ b/.ci/utils/use-esy.yml
@@ -1,5 +1,5 @@
 # steps to install esy globally
 
 steps:
-  - script: "npm install -g esy@0.5.6"
+  - script: "npm install -g esy@0.5.8"
     displayName: "install esy"

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ no dependencies.
   - When asked how to configure the new pipeline, select the option to use
     existing configuration inside the repo.
 
-The CI is configured to build caches on the `master` branch, and also any
-branch named one of (`global`, `release-*`, `releases-*`). That means that pull
-requests to any branch with those names will be fast, once you have landed at
-least one commit to that branch. The first time you submit a pull request to
-one of those branches, the builds will be slow but then subsequent pull
-requests will be faster once a pull request is merged to it.
+The CI is configured to build caches on the `master` branch as well as any pull
+request run. Cache keys depend on the platform where builds are run (Linux,
+macOS or Windows) as well as the hash of the contents from `esy.lock` file.
+In case there is not a match for the current run key, there is a fallback to
+get the latest created key for the current run platform.
+Cache isolation and security applies thanks to Azure infrastructure. To know
+more about this, check the documentation about ["Cache isolation and
+security"](https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#cache-isolation-and-security).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: Build npm release
+name: $(Build.SourceVersionMessage)
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,14 @@
 name: Build npm release
 
 trigger:
-  - master
-  - global
-  - release-*
-  - releases-*
-  - feature-*
+  branches:
+    include:
+      - master
+
+pr:
+  branches:
+    include:
+      - "*"
 
 jobs:
   - template: .ci/build-platform.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: $(Build.SourceVersionMessage)
+name: Build npm release
 
 trigger:
   branches:


### PR DESCRIPTION
It seems Azure `Cache` tasks are out of beta, starting from v2:
- Announcement: https://azure.microsoft.com/en-us/updates/new-deployment-strategies-and-caching-for-azure-pipelines/
- https://github.com/microsoft/azure-pipelines-tasks/blob/c9c4827c8d0951c98a9468d83db708c593c7c428/Tasks/CacheV2/task.json
- https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#using-the-cache-task

This PR updates the template to use them, plus updates esy to 0.5.8.