### PR TITLE
rm -rf instead of rm -r to supress warnings if no cached ocamlfind

### DIFF
--- a/.ci/utils/restore-build-cache.yml
+++ b/.ci/utils/restore-build-cache.yml
@@ -87,7 +87,7 @@ steps:
       targetType: 'inline' # Optional. Options: filePath, inline
       script: |
         ls ${ESY__CACHE_INSTALL_PATH}
-        rm -r ${ESY__CACHE_INSTALL_PATH}/opam__s__ocamlfind*
+        rm -rf ${ESY__CACHE_INSTALL_PATH}/opam__s__ocamlfind*
 
   - bash: 'rm -rf _import'
     continueOnError: true


### PR DESCRIPTION
This fixes issues like this
![image](https://user-images.githubusercontent.com/5252755/71496637-22177200-2809-11ea-941f-1cef9b096f5d.png)
