### PR TITLE
Extracts out esy build steps

### DIFF
--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -62,19 +62,7 @@ jobs:
       # displayName: "Print esy bin location"
       - bash: env
         displayName: "Print environment"
-      - template: utils/use-node.yml
-      - template: utils/use-esy.yml
-      - script: "esy install"
-        displayName: "esy install"
-      - template: utils/restore-build-cache.yml
-      - script: "esy build"
-        displayName: "esy build"
-      - template: utils/create-docs.yml
-      - script: "esy test"
-        displayName: "Test command"
-      - script: "esy release"
-        displayName: "esy release"
-      - template: utils/publish-build-cache.yml
+      - template: esy-build-steps.yml
       - task: PublishBuildArtifacts@1
         displayName: "Publish Artifact: ${{ parameters.platform }}"
         inputs:

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -3,13 +3,17 @@
 steps:
   - template: utils/use-node.yml
   - template: utils/use-esy.yml
+  - script: "esy install"
+    displayName: "esy install"
   - template: utils/restore-build-cache.yml
-  - script: esy install
-    displayName: 'esy install'
-  - script: esy build
-    displayName: 'esy build'
+  - script: "esy build"
+    displayName: "esy build"
+  - template: utils/create-docs.yml
+  - script: "esy test"
+    displayName: "Test command"
+  - script: "esy release"
+    displayName: "esy release"
   - template: utils/publish-build-cache.yml
-  - script: esy x refmt --version
-    displayName: 'esy x refmt --version'
+
   # Run tests or any additional steps here
   # - script: esy b dune runtest


### PR DESCRIPTION
Since most people copy the setup to get started with, I thought it was
imported to keep the project specific steps separate so that they can
port changes we make here easily