### PR TITLE
Add --promote-install-files to remove esy.install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "esy": {
     "build": "dune build -p #{self.name}",
-    "buildDev": "refmterr dune build --root . --only-package #{self.name}",
-    "install": "esy-installer #{self.target_dir / 'default' / self.name '.install'}",
+    "buildDev": "refmterr dune build --promote-install-files --root . --only-package #{self.name}",
     "NOTE": "Optional release Section. Customizes result of `esy release`",
     "release": {
       "bin": [


### PR DESCRIPTION
In response to
> I'm slightly concerned that we need that install to make it work since this is a very simple project. I wonder if we need to do changes somewhere to just have the default install work.

_Originally posted by @ulrikstrid in https://github.com/esy-ocaml/hello-reason/pull/61#issuecomment-581308539_