### PR TITLE
Add formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,16 @@ And test compiled executable (runs `scripts.tests` specified in
 
     % esy test
 
-Documentation for the libraries in the project can be generated with:
+You can format your code (runs `scripts.format` specified in `package.json`):
+
+    % esy format
+
+If you plan to add some .ml(i) files and want to enable formatting you can
+run: `esy add "@opam/ocamlformat"` and `esy format` will be automatically
+extended.
+
+Documentation for the libraries in the project can be generated with (runs
+`scripts.doc` specified in `package.json`):
 
     % esy doc
     % esy open '#{self.target_dir}/default/_doc/_html/index.html'

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
-  (name Hello)
-  (public_name Hello)
-  (libraries console.lib lib))
+ (name Hello)
+ (public_name Hello)
+ (libraries console.lib lib))

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,5 @@
 (lang dune 1.0)
+; this is enable by default with (lang dune 2.0)
+; https://dune.readthedocs.io/en/stable/formatting.html#lang-dune-2-0
+; when changing dune lang here we should be able to get rid of this line
+(using fmt 1.2)

--- a/lib/Util.rei
+++ b/lib/Util.rei
@@ -5,5 +5,4 @@
     {[
     print_endline(hello());
     ]} */
-let hello: (unit) => string;
-
+let hello: unit => string;

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,6 @@
 (library
-  (name lib)
-  (flags (-w -40 -w +26))
-  (public_name hello-reason)
-  (libraries  pastel.lib))
+ (name lib)
+ (flags
+  (-w -40 -w +26))
+ (public_name hello-reason)
+ (libraries pastel.lib))

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "test": "esy x Hello",
+    "format": "esy dune build @fmt --auto-promote",
     "doc": "esy dune build @doc"
   },
   "dependencies": {


### PR DESCRIPTION
I backport idea of https://github.com/revery-ui/revery where you can run `esy format` to format all your code. `esy format` in revery also format c code and pull `esy-astyle` but here we don't have c stub so it is fine☺. I have also added a note for user who want to use .ml(i) inside.

Should I add a task in GHA CI ?