### PR TITLE
Make `esy test` really test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ again with the same simple `esy` command.
 
     % esy
 
-And test compiled executable (runs `scripts.tests` specified in
+And run compiled executable (runs `scripts.run` specified in
+  `package.json`):
+
+    % esy run
+
+You can test your code (runs `scripts.test` specified in
 `package.json`):
 
     % esy test

--- a/lib/Util.re
+++ b/lib/Util.re
@@ -7,3 +7,5 @@ let hello = () =>
       "!"
     </Pastel>
   );
+
+let add = (a, b) => a + b;

--- a/lib/Util.rei
+++ b/lib/Util.rei
@@ -6,3 +6,7 @@
     print_endline(hello());
     ]} */
 let hello: unit => string;
+
+/** A simple function to show how to write test.
+*/
+let add: (int, int) => int;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     }
   },
   "scripts": {
-    "test": "esy x Hello",
+    "test": "esy b dune exec ./test/TestRunner.exe #{self.root}",
+    "run": "esy x Hello",
     "format": "esy dune build @fmt --auto-promote",
     "doc": "esy dune build @doc"
   },

--- a/test/TestRunner.re
+++ b/test/TestRunner.re
@@ -1,0 +1,1 @@
+TestLib.TestFramework.cli();

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(executable
+ (name TestRunner)
+ (libraries testLib))

--- a/test/lib/TestFramework.re
+++ b/test/lib/TestFramework.re
@@ -1,0 +1,18 @@
+// In package.json we pass #{self.root} as first argument
+if (Array.length(Sys.argv) < 2)
+  failwith("pass the project root as first argument");
+let projectDir = Sys.argv[1];
+
+include Rely.Make({
+  let config =
+    Rely.TestFrameworkConfig.initialize({
+      snapshotDir:
+        Filename.(
+          projectDir
+          |> (dir => concat(dir, "test"))
+          |> (dir => concat(dir, "lib"))
+          |> (dir => Filename.concat(dir, "__snapshots__"))
+        ),
+      projectDir,
+    });
+});

--- a/test/lib/UtilTest.re
+++ b/test/lib/UtilTest.re
@@ -1,0 +1,9 @@
+open TestFramework;
+
+open Lib;
+
+describe("Util", ({test, _}) => {
+  test("add", ({expect, _}) => {
+    expect.int(Util.add(3, 3)).toBe(6)
+  })
+});

--- a/test/lib/dune
+++ b/test/lib/dune
@@ -1,0 +1,8 @@
+(library
+ (name testLib)
+ ; the linkall flag ensures that all of our tests are compiled and the
+ ; -g flag emits debugging information
+ (ocamlopt_flags -linkall -g)
+ ; you will want to depend on the library you are testing as well, however for
+ ; the purposes of this example we are only depending on the test runner itself
+ (libraries lib rely.lib))


### PR DESCRIPTION
`esy test` was used to exec the main and not for test the code. I fix it + add explanation in the README.md.