### PR TITLE
Fixes Windows CI: prepend '/c/Program Files/Git/bin'

### DIFF
--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -16,10 +16,10 @@ jobs:
       # Needed so that the mingw tar doesn't shadow the system tar. See
       # pipelines.yaml. We need windows bsdtar from system32, not the mingw
       # one. Note powershell doesn't need escaping of backslashes.
-      - powershell: Write-Host "##vso[task.setvariable variable=PATH;]C:\Windows\system32;${env:PATH}"
+      - powershell: Write-Host "##vso[task.setvariable variable=PATH;]C:\Program Files\Git\bin;C:\Windows\system32;${env:PATH}"
         continueOnError: true
         condition: eq(variables['AGENT.OS'], 'Windows_NT')
-        displayName: "Make sure windows/system32 is at front of path if windows"
+        displayName: "Make sure C:/Program Files/Git/bin and windows/system32 is at front of path if windows"
       - powershell: $Env:Path
         continueOnError: true
         condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))))


### PR DESCRIPTION
Cherry-Picked from
https://github.com/facebook/reason/commit/d3822b78b9a8c37594d3d5bff640f9159af0e298:
Fixes Windows CI: prepend '/c/Program Files/Git/bin' (#2611)

* Fixes Windows CI: prepend '/c/Program Files/Git/bin'

Bash@3 started failing after a recent change related to WSL

https://github.com/actions/virtual-environments/pull/1081
https://github.com/actions/virtual-environments/pull/1276

* Fix slashes

* Pick bash from env

closes #73 