### PR TITLE
Update actions/setup-node to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/setup-node@v1.4.3
+      - uses: actions/setup-node@v2
         with:
           node-version: 12
       - uses: actions/checkout@v2.3.2
@@ -56,7 +56,7 @@ jobs:
         run: esy build --release
 
       # Now that our core project build let builds others deps
-      - name: Build  dependencies
+      - name: Build dependencies
         if: steps.deps-cache.outputs.cache-hit != 'true'
         run: esy build-dependencies
 


### PR DESCRIPTION
Updated to v2 setup-node since ubuntu-latest fails due a change on the image where they remove the possibility to run unsafe commands as "add-path" which could monkey patch a cli.

Tried here: https://github.com/davesnx/try-esy-cache-gh-actions/runs/1720707365#step:2:5